### PR TITLE
Bump openjdk version to 7u75-2.5.4-1~utopic1

### DIFF
--- a/openjdk-fontfix/build_packages.sh
+++ b/openjdk-fontfix/build_packages.sh
@@ -47,4 +47,4 @@ function build {
 }
 
 
-build utopic 7u71-2.5.3-0ubuntu1 ppa1
+build utopic 7u75-2.5.4-1~utopic1 ppa1


### PR DESCRIPTION
Recent package updates in Ubuntu have overridden the patch. This fix bumps the package version.